### PR TITLE
Add a "do-begin" form, rename cluster/task to defcluster/deftask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+pom.xml
+*jar
+/lib/
+/classes/
+.lein-deps-sum
+.lein-failures
+*.swp
+autodoc/**

--- a/samples/controls.clj
+++ b/samples/controls.clj
@@ -4,20 +4,20 @@
 ;;
 ;;
 (ns samples
-  (:use [control.core :only [task cluster scp ssh begin]]))
+  (:use [control.core :only [deftask defcluster scp ssh begin]]))
 ;;define clusters
-(cluster :mycluster
+(defcluster :mycluster
 		 :clients [
 				   { :host "a.domain.com" :user "alogin"}
 				   { :host "b.domain.com" :user "blogin"}
 				   ])
 
 ;;define tasks
-(task :date "Get date"
+(deftask :date "Get date"
 	  []
 	  (ssh "date"))
 
-(task :deploy "scp files to remote machines"
+(deftask :deploy "scp files to remote machines"
 	  [file1 file2]
 	  (scp (file1 file2) "/home/alogin/"))
 

--- a/test/control/test/core.clj
+++ b/test/control/test/core.clj
@@ -24,7 +24,7 @@
 
 (deftest test-task
   (is (= 0 (count @tasks)))
-  (task :test "test task"
+  (deftask :test "test task"
 		[]
 		(+ 1 2))
   (is (= 1 (count @tasks)))
@@ -36,7 +36,7 @@
 
 (deftest test-cluster
   (is (= 0 (count @clusters)))
-  (cluster :mycluster
+  (defcluster :mycluster
 		   :clients [{:host "a.domain.com" :user "apple"}]
 		   :addresses ["a.com" "b.com"]
 		   :user "dennis"
@@ -57,7 +57,7 @@
 
 (with-private-fns [control.core [perform spawn await-process]]
   (deftest test-perform
-	(task :test "test-task"
+	(deftask :test "test-task"
 		  [a b]
 		  (+ a b))
 	(let [t (:test @tasks)]


### PR DESCRIPTION
I made following changes to clojure-control
- Add a "do-begin" API for external invocation. (I'm working on a leiningen plugin for clojure-control)
- Rename macros to defcluster/deftask, following the clojure manner.
