### PR TITLE
Make scp a function

### DIFF
--- a/src/control/core.clj
+++ b/src/control/core.clj
@@ -58,12 +58,12 @@
   (exec host user ["ssh" (ssh-client host user) cmd]))
 
 
-(defmacro scp
+(defn scp
   [host user files remoteDir]
-  `(do (log-with-tag ~host "scp"
-         (join " " (concat ~files [ " ==> " ~remoteDir])))
-       (exec ~host ~user ["scp" ~@files (str (ssh-client ~host ~user) ":"
-                                             ~remoteDir)])))
+  (log-with-tag host "scp"
+    (join " " (concat files [ " ==> " remoteDir])))
+  (exec host user
+        (concat ["scp"] files [(str (ssh-client host user) ":" remoteDir)])))
 
 
 

--- a/test/control/test/core.clj
+++ b/test/control/test/core.clj
@@ -48,7 +48,7 @@
 	(is (= [{:host "a.domain.com" :user "apple"}] (:clients m)))
 	(is (= "dennis" (:user m)))
 	(is (= ["a.com" "b.com"] (:addresses m)))))
-  
+
 
 (defmacro with-private-fns [[ns fns] & tests]
   "Refers private fns from ns and runs tests in context."
@@ -71,6 +71,8 @@
 		(is (blank? (:stderr execp)))
 	))))
 
-  
-
-
+(deftest test-scp
+  (binding [exec (fn [h u c] c)]
+    (let [files ["a.text" "b.txt"]]
+      (is (= '("scp" "a.text" "b.txt" "user@host:/tmp")
+             (scp "host" "user" files "/tmp"))))))


### PR DESCRIPTION
I need to pass the file list in a var instead of as an explicit list. `~@files` would fail if `files` was a var.

And I don't see a good reason for `scp` to be a macro.
