### PR TITLE
relaxing validation of passed keys: 

### DIFF
--- a/src/control/core.clj
+++ b/src/control/core.clj
@@ -155,7 +155,7 @@
                           ssh-options
                           [(ssh-client host user) cmd]))))
 
-(defn rsync 
+(defn rsync
   "Rsync local files to remote machine's files,for example:
      (deftask :deploy \"scp files to remote machines\" []
     (rsync \"src/\" \":/home/login\"))
@@ -348,8 +348,8 @@
                    debug (:debug cluster)
                    log (or (:log cluster) true)
                    clients (if (nil? cluster) (create-clients (first args)) clients)]
-               (check-valid-options cluster :user :clients :addresses :parallel :includes :debug :log :ssh-options :scp-options :rsync-options :name)
-               ;;if task is nil,exit 
+               (check-valid-options cluster :user :clients :addresses :parallel :includes :debug :log :ssh-options :scp-options :rsync-options :name :options)
+               ;;if task is nil,exit
                (when-exit (nil? task)
                           (str "No task named " (name task-name)))
                (when-exit (and (empty? addresses)
@@ -387,4 +387,3 @@
 
 (defn begin []
   (do-begin *command-line-args*))
-


### PR DESCRIPTION
by allowing a key options to be passed in it's now possible to specify cluster-wide variables

For example this control file would now work: 

```
(defcluster :int
  :options {
      :clj_fe_zk_root "clj-fe-zk-int"
      :clj-fe-zk-conn-str "10.251.76.40:2181,10.251.76.52:2181"}
  :clients [
    {:host "10.251.76.72" :user "root"}])

(defcluster :prod  
  :options {
      :clj_fe_zk_root "clj-fe-zk-prod"
      :clj-fe-zk-conn-str "10.250.76.63:2181,10.250.76.118:2181,10.250.76.119:2181"}
  :clients [
    {:host "10.250.76.180" :user "root" }])

(deftask :print-zk-options "printouts zk options for cluster" []
  (println (-> cluster :options :clj_fe_zk_root))
  (println (-> cluster :options :clj-fe-zk-conn-str)))
```
